### PR TITLE
Certificate processing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <authlete-java-common.version>2.11</authlete-java-common.version>
+        <authlete-java-common.version>2.17</authlete-java-common.version>
         <gson.version>2.6.2</gson.version>
     </properties>
 

--- a/src/main/java/com/authlete/jaxrs/AccessTokenValidator.java
+++ b/src/main/java/com/authlete/jaxrs/AccessTokenValidator.java
@@ -75,7 +75,7 @@ public class AccessTokenValidator extends BaseHandler
      */
     public AccessTokenInfo validate(String accessToken) throws WebApplicationException
     {
-        return validate(accessToken, null, null);
+        return validate(accessToken, null, null, null);
     }
 
 
@@ -113,7 +113,7 @@ public class AccessTokenValidator extends BaseHandler
      */
     public AccessTokenInfo validate(String accessToken, String[] requiredScopes) throws WebApplicationException
     {
-        return validate(accessToken, requiredScopes, null);
+        return validate(accessToken, requiredScopes, null, null);
     }
 
 
@@ -138,6 +138,11 @@ public class AccessTokenValidator extends BaseHandler
      * @param requiredSubject
      *         Subject (= user's unique identifier) that must be associated
      *         with the access token. {@code null} is okay.
+     *         
+     * @param clientCertificate 
+     *         TLS Certificate of the client presented during a call to
+     *         the resource server, used with TLS-bound access tokens. 
+     *         Can be {@code null} if no certificate is presented.
      *
      * @return
      *         Information about the access token.
@@ -153,7 +158,7 @@ public class AccessTokenValidator extends BaseHandler
      *         </ol>
      */
     public AccessTokenInfo validate(
-            String accessToken, String[] requiredScopes, String requiredSubject) throws WebApplicationException
+            String accessToken, String[] requiredScopes, String requiredSubject, String clientCertificate) throws WebApplicationException
     {
         if (accessToken == null)
         {
@@ -163,7 +168,7 @@ public class AccessTokenValidator extends BaseHandler
 
         try
         {
-            return process(accessToken, requiredScopes, requiredSubject);
+            return process(accessToken, requiredScopes, requiredSubject, clientCertificate);
         }
         catch (WebApplicationException e)
         {
@@ -178,10 +183,10 @@ public class AccessTokenValidator extends BaseHandler
 
 
     private AccessTokenInfo process(
-            String accessToken, String[] scopes, String subject) throws WebApplicationException
+            String accessToken, String[] scopes, String subject, String clientCertificate) throws WebApplicationException
     {
         // Call Authlete's /api/auth/introspection API.
-        IntrospectionResponse response = getApiCaller().callIntrospection(accessToken, scopes, subject);
+        IntrospectionResponse response = getApiCaller().callIntrospection(accessToken, scopes, subject, clientCertificate);
 
         // 'action' in the response denotes the next action which
         // this service implementation should take.

--- a/src/main/java/com/authlete/jaxrs/AuthleteApiCaller.java
+++ b/src/main/java/com/authlete/jaxrs/AuthleteApiCaller.java
@@ -339,11 +339,11 @@ class AuthleteApiCaller
      */
     public TokenResponse callToken(
             MultivaluedMap<String, String> parameters, String clientId, String clientSecret,
-            Property[] properties)
+            Property[] properties, String clientCertificate, String[] clientCertificatePath)
     {
         String params = URLCoder.formUrlEncode(parameters);
 
-        return callToken(params, clientId, clientSecret, properties);
+        return callToken(params, clientId, clientSecret, properties, clientCertificate, clientCertificatePath);
     }
 
 
@@ -351,7 +351,7 @@ class AuthleteApiCaller
      * Call Authlete's {@code /api/auth/token} API.
      */
     private TokenResponse callToken(
-            String parameters, String clientId, String clientSecret, Property[] properties)
+            String parameters, String clientId, String clientSecret, Property[] properties, String clientCertificate, String[] clientCertificatePath)
     {
         if (parameters == null)
         {
@@ -367,6 +367,8 @@ class AuthleteApiCaller
             .setClientId(clientId)
             .setClientSecret(clientSecret)
             .setProperties(properties)
+            .setClientCertificate(clientCertificate)
+            .setClientCertificatePath(clientCertificatePath)
             ;
 
         try

--- a/src/main/java/com/authlete/jaxrs/AuthleteApiCaller.java
+++ b/src/main/java/com/authlete/jaxrs/AuthleteApiCaller.java
@@ -736,13 +736,14 @@ class AuthleteApiCaller
     /**
      * Call Authlete's {@code /api/auth/introspection} API.
      */
-    public IntrospectionResponse callIntrospection(String accessToken, String[] scopes, String subject)
+    public IntrospectionResponse callIntrospection(String accessToken, String[] scopes, String subject, String clientCertificate)
     {
         // Create a request for /api/auth/introspection API.
         IntrospectionRequest request = new IntrospectionRequest()
             .setToken(accessToken)
             .setScopes(scopes)
-            .setSubject(subject);
+            .setSubject(subject)
+            .setClientCertificate(clientCertificate);
 
         try
         {

--- a/src/main/java/com/authlete/jaxrs/BaseEndpoint.java
+++ b/src/main/java/com/authlete/jaxrs/BaseEndpoint.java
@@ -17,7 +17,15 @@
 package com.authlete.jaxrs;
 
 
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.WebApplicationException;
+
+import org.apache.commons.codec.binary.Base64;
 
 
 /**
@@ -29,6 +37,20 @@ import javax.ws.rs.WebApplicationException;
  */
 public class BaseEndpoint
 {
+    /** 
+     * Headers to check for certificate path with proxy-forwarded certificate 
+     * information; the first entry is the client's certificate itself 
+     */
+    private String[] clientCertificatePathHeaders = {
+            "X-Ssl-Cert", // the client's certificate 
+            "X-Ssl-Cert-Chain-1", "X-Ssl-Cert-Chain-2", "X-Ssl-Cert-Chain-3", "X-Ssl-Cert-Chain-4" // the intermediate certificate path, not including the client's certificate or root
+    };
+    
+    /*
+     * Used for handling PEM format certificates.
+     */
+    private Base64 base64 = new Base64(Base64.PEM_CHUNK_SIZE, "\n".getBytes());
+    
     /**
      * Called when the internal request handler raises an exception.
      * The default implementation of this method calls {@code
@@ -42,4 +64,77 @@ public class BaseEndpoint
     {
         exception.printStackTrace();
     }
+
+    protected String[] extractClientCertificateChain(HttpServletRequest request)
+    {
+        // try to get the certificates from the servlet context directly
+        X509Certificate[] certs = (X509Certificate[]) request.getAttribute("javax.servlet.request.X509Certificate");
+        
+        if (certs == null || certs.length == 0)
+        {
+            // we didn't find any certificates in the servlet request, try extracting them from the headers instead
+            List<String> headerCerts = new ArrayList<>();
+            
+            for (String headerName : clientCertificatePathHeaders)
+            {
+                String header = request.getHeader(headerName);
+                if (header != null)
+                {
+                    headerCerts.add(header);
+                }
+            }
+
+            if (headerCerts.isEmpty())
+            {
+                return null;
+            }
+            else
+            {
+                return headerCerts.toArray(new String[] {});
+            }
+        }
+        else 
+        {
+            String[] pemEncoded = new String[certs.length];
+            
+            try
+            {
+                for (int i = 0; i < certs.length; i++)
+                {
+                    // encode each certificate in PEM format
+                    StringBuilder sb = new StringBuilder();
+                    sb.append("-----BEGIN CERTIFICATE-----\n");
+                    sb.append(base64.encode(certs[i].getEncoded()));
+                    sb.append("\n-----END CERTIFICATE-----\n");
+
+                    pemEncoded[i] = sb.toString();
+                    
+                }
+            } catch (CertificateEncodingException e)
+            {
+                // TODO What should be done with this error?
+                e.printStackTrace();
+                return null;
+            }
+            
+            return pemEncoded;
+            
+        }
+        
+    }
+    
+    protected String extractClientCertificate(HttpServletRequest request)
+    {
+        String[] certs = extractClientCertificateChain(request);
+        
+        if (certs != null && certs.length > 0)
+        {
+            return certs[0];
+        }
+        else
+        {
+            return null;
+        }
+    }
+    
 }

--- a/src/main/java/com/authlete/jaxrs/BaseResourceEndpoint.java
+++ b/src/main/java/com/authlete/jaxrs/BaseResourceEndpoint.java
@@ -95,7 +95,7 @@ public class BaseResourceEndpoint extends BaseEndpoint
      */
     public AccessTokenInfo validateAccessToken(AuthleteApi api, String accessToken) throws WebApplicationException
     {
-        return validateAccessToken(api, accessToken, null, null);
+        return validateAccessToken(api, accessToken, null, null, null);
     }
 
 
@@ -129,7 +129,7 @@ public class BaseResourceEndpoint extends BaseEndpoint
     public AccessTokenInfo validateAccessToken(
             AuthleteApi api, String accessToken, String[] requiredScopes) throws WebApplicationException
     {
-        return validateAccessToken(api, accessToken, requiredScopes, null);
+        return validateAccessToken(api, accessToken, requiredScopes, null, null);
     }
 
 
@@ -168,6 +168,11 @@ public class BaseResourceEndpoint extends BaseEndpoint
      * @param requiredSubject
      *         Subject (= user's unique identifier) that must be associated
      *         with the access token. {@code null} is okay.
+     *         
+     * @param clientCertificate 
+     *         TLS Certificate of the client presented during a call to
+     *         the resource server, used with TLS-bound access tokens. 
+     *         Can be {@code null} if no certificate is presented.
      *
      * @return
      *         Information about the access token.
@@ -183,13 +188,13 @@ public class BaseResourceEndpoint extends BaseEndpoint
      *         </ol>
      */
     public AccessTokenInfo validateAccessToken(
-            AuthleteApi api, String accessToken, String[] requiredScopes, String requiredSubject) throws WebApplicationException
+            AuthleteApi api, String accessToken, String[] requiredScopes, String requiredSubject, String clientCertificate) throws WebApplicationException
     {
         try
         {
             // Validate the access token and obtain the information about it.
             return new AccessTokenValidator(api)
-                    .validate(accessToken, requiredScopes, requiredSubject);
+                    .validate(accessToken, requiredScopes, requiredSubject, clientCertificate);
         }
         catch (WebApplicationException e)
         {

--- a/src/main/java/com/authlete/jaxrs/BaseResourceEndpoint.java
+++ b/src/main/java/com/authlete/jaxrs/BaseResourceEndpoint.java
@@ -77,8 +77,8 @@ public class BaseResourceEndpoint extends BaseEndpoint
 
     /**
      * Validate an access token. This method is an alias of {@link
-     * #validateAccessToken(AuthleteApi, String, String[], String)
-     * validate}<code>(api, accessToken, null, null, null)</code>.
+     * #validateAccessToken(AuthleteApi, String, String[], String, String)
+     * validateAccessToken}<code>(api, accessToken, null, null, null)</code>.
      *
      * @param api
      *         Implementation of {@link AuthleteApi} interface.
@@ -101,8 +101,8 @@ public class BaseResourceEndpoint extends BaseEndpoint
 
     /**
      * Validate an access token. This method is an alias of {@link
-     * #validateAccessToken(AuthleteApi, String, String[], String)
-     * validate}<code>(api, accessToken, requiredScopes, null, null)</code>.
+     * #validateAccessToken(AuthleteApi, String, String[], String, String)
+     * validateAccessToken}<code>(api, accessToken, requiredScopes, null, null)</code>.
      *
      * @param api
      *         Implementation of {@link AuthleteApi} interface.
@@ -135,8 +135,8 @@ public class BaseResourceEndpoint extends BaseEndpoint
 
     /**
      * Validate an access token. This method is an alias of {@link
-     * #validateAccessToken(AuthleteApi, String, String[], String)
-     * validate}<code>(api, accessToken, requiredScopes, requiredSubject, null)</code>.
+     * #validateAccessToken(AuthleteApi, String, String[], String, String)
+     * validateAccessToken}<code>(api, accessToken, requiredScopes, requiredSubject, null)</code>.
      *
      * @param api
      *         Implementation of {@link AuthleteApi} interface.
@@ -176,7 +176,7 @@ public class BaseResourceEndpoint extends BaseEndpoint
      *
      * <p>
      * This method internally creates a {@link AccessTokenValidator} instance and
-     * calls its {@link AccessTokenValidator#validate(String, String[], String)
+     * calls its {@link AccessTokenValidator#validate(String, String[], String, String)
      * validate()} method. Then, this method uses the value returned from the
      * {@code validate()} method as a response from this method.
      * </p>

--- a/src/main/java/com/authlete/jaxrs/BaseResourceEndpoint.java
+++ b/src/main/java/com/authlete/jaxrs/BaseResourceEndpoint.java
@@ -78,7 +78,7 @@ public class BaseResourceEndpoint extends BaseEndpoint
     /**
      * Validate an access token. This method is an alias of {@link
      * #validateAccessToken(AuthleteApi, String, String[], String)
-     * validate}<code>(api, accessToken, null, null)</code>.
+     * validate}<code>(api, accessToken, null, null, null)</code>.
      *
      * @param api
      *         Implementation of {@link AuthleteApi} interface.
@@ -102,7 +102,7 @@ public class BaseResourceEndpoint extends BaseEndpoint
     /**
      * Validate an access token. This method is an alias of {@link
      * #validateAccessToken(AuthleteApi, String, String[], String)
-     * validate}<code>(api, accessToken, requiredScopes, null)</code>.
+     * validate}<code>(api, accessToken, requiredScopes, null, null)</code>.
      *
      * @param api
      *         Implementation of {@link AuthleteApi} interface.
@@ -130,6 +130,44 @@ public class BaseResourceEndpoint extends BaseEndpoint
             AuthleteApi api, String accessToken, String[] requiredScopes) throws WebApplicationException
     {
         return validateAccessToken(api, accessToken, requiredScopes, null, null);
+    }
+
+
+    /**
+     * Validate an access token. This method is an alias of {@link
+     * #validateAccessToken(AuthleteApi, String, String[], String)
+     * validate}<code>(api, accessToken, requiredScopes, requiredSubject, null)</code>.
+     *
+     * @param api
+     *         Implementation of {@link AuthleteApi} interface.
+     *
+     * @param accessToken
+     *         An access token to validate.
+     *
+     * @param requiredScopes
+     *         Scopes that must be associated with the access token.
+     *         {@code null} is okay.
+     *
+     * @param requiredSubject
+     *         Subject (= user's unique identifier) that must be associated
+     *         with the access token. {@code null} is okay.
+     *         
+     * @return
+     *         Information about the access token.
+     *
+     * @throws WebApplicationException
+     *         The access token is invalid. To be concrete, one or more of
+     *         the following conditions meet.
+     *         <ol>
+     *           <li>The access token does not exist.
+     *           <li>The access token has expired.
+     *           <li>The access token does not cover the required scopes.
+     *         </ol>
+     */
+    public AccessTokenInfo validateAccessToken(
+            AuthleteApi api, String accessToken, String[] requiredScopes, String requiredSubject) throws WebApplicationException
+    {
+        return validateAccessToken(api, accessToken, requiredScopes, requiredSubject, null);
     }
 
 

--- a/src/main/java/com/authlete/jaxrs/BaseTokenEndpoint.java
+++ b/src/main/java/com/authlete/jaxrs/BaseTokenEndpoint.java
@@ -71,12 +71,9 @@ public class BaseTokenEndpoint extends BaseEndpoint
      * @param authorization
      *         The value of {@code Authorization} header of the token request.
      *         
-     * @param clientCertificate
-     *         The client certificate used in mutual TLS authentication, in PEM format.
-     *          
      * @param clientCertificatePath
-     *         The certificate path used in mutual TLS authentication, in PEM format, not
-     *         including the client's certificate. 
+     *         The certificate path used in mutual TLS authentication, in PEM format. The
+     *         client's own certificate is the first in this array. Can be {@code null}.
      *
      * @return
      *         A response that should be returned to the client application.

--- a/src/main/java/com/authlete/jaxrs/BaseTokenEndpoint.java
+++ b/src/main/java/com/authlete/jaxrs/BaseTokenEndpoint.java
@@ -70,13 +70,20 @@ public class BaseTokenEndpoint extends BaseEndpoint
      *
      * @param authorization
      *         The value of {@code Authorization} header of the token request.
+     *         
+     * @param clientCertificate
+     *         The client certificate used in mutual TLS authentication, in PEM format.
+     *          
+     * @param clientCertificatePath
+     *         The certificate path used in mutual TLS authentication, in PEM format, not
+     *         including the client's certificate. 
      *
      * @return
      *         A response that should be returned to the client application.
      */
     public Response handle(
             AuthleteApi api, TokenRequestHandlerSpi spi,
-            MultivaluedMap<String, String> parameters, String authorization)
+            MultivaluedMap<String, String> parameters, String authorization, String[] clientCertificatePath)
     {
         try
         {
@@ -84,7 +91,7 @@ public class BaseTokenEndpoint extends BaseEndpoint
             TokenRequestHandler handler = new TokenRequestHandler(api, spi);
 
             // Delegate the task to the handler.
-            return handler.handle(parameters, authorization);
+            return handler.handle(parameters, authorization, clientCertificatePath);
         }
         catch (WebApplicationException e)
         {

--- a/src/main/java/com/authlete/jaxrs/ClientCertificateExtractor.java
+++ b/src/main/java/com/authlete/jaxrs/ClientCertificateExtractor.java
@@ -1,0 +1,27 @@
+package com.authlete.jaxrs;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Extracts a client's MTLS certificate from an incoming HTTP Request.
+ * 
+ * @author jricher
+ *
+ */
+public interface ClientCertificateExtractor
+{
+
+    /**
+     * Search the given request for a client's certificate and return it as a string
+     * of certificates in PEM format. 
+     * 
+     * @param request
+     *          The incoming HTTP request to search.
+     *          
+     * @return
+     *          The client's MTLS certificate chain. All certificates are in PEM format,
+     *          the first certificate is the client's own certificate.
+     */
+    String[] extractClientCertificateChain(HttpServletRequest request);
+    
+}

--- a/src/main/java/com/authlete/jaxrs/HeaderClientCertificateExtractor.java
+++ b/src/main/java/com/authlete/jaxrs/HeaderClientCertificateExtractor.java
@@ -9,7 +9,7 @@ import javax.servlet.http.HttpServletRequest;
 /**
  * 
  * Extracts the client certificate from headers defined by the {@code 
- * clientCertificatePathHeaders} member list. The first element in the list is 
+ * clientCertificateChainHeaders} member list. The first element in the list is 
  * header for the client's own certificate. Each additional header in the list
  * will be checked and added to the resulting output.
  * 

--- a/src/main/java/com/authlete/jaxrs/HeaderClientCertificateExtractor.java
+++ b/src/main/java/com/authlete/jaxrs/HeaderClientCertificateExtractor.java
@@ -1,6 +1,7 @@
 package com.authlete.jaxrs;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
@@ -24,10 +25,10 @@ public class HeaderClientCertificateExtractor implements ClientCertificateExtrac
      * Headers to check for certificate path with proxy-forwarded certificate 
      * information; the first entry is the client's certificate itself 
      */
-    private String[] clientCertificateChainHeaders = {
+    private List<String> clientCertificateChainHeaders = Arrays.asList(
             "X-Ssl-Cert", // the client's certificate 
             "X-Ssl-Cert-Chain-1", "X-Ssl-Cert-Chain-2", "X-Ssl-Cert-Chain-3", "X-Ssl-Cert-Chain-4" // the intermediate certificate path, not including the client's certificate or root
-    };
+    );
     
     /* (non-Javadoc)
      * @see com.authlete.jaxrs.ClientCertificateExtractor#extractClientCertificateChain(javax.servlet.http.HttpServletRequest)
@@ -62,7 +63,7 @@ public class HeaderClientCertificateExtractor implements ClientCertificateExtrac
      * the list is header for the client's own certificate. Each additional header in the list
      * will be checked and added to the resulting output.
      */
-    public String[] getClientCertificateChainHeaders()
+    public List<String> getClientCertificateChainHeaders()
     {
         return clientCertificateChainHeaders;
     }
@@ -72,7 +73,7 @@ public class HeaderClientCertificateExtractor implements ClientCertificateExtrac
      * the list is header for the client's own certificate. Each additional header in the list
      * will be checked and added to the resulting output.
      */
-    public HeaderClientCertificateExtractor setClientCertificateChainHeaders(String[] clientCertificateChainHeaders)
+    public HeaderClientCertificateExtractor setClientCertificateChainHeaders(List<String> clientCertificateChainHeaders)
     {
         this.clientCertificateChainHeaders = clientCertificateChainHeaders;
         

--- a/src/main/java/com/authlete/jaxrs/HeaderClientCertificateExtractor.java
+++ b/src/main/java/com/authlete/jaxrs/HeaderClientCertificateExtractor.java
@@ -1,0 +1,82 @@
+package com.authlete.jaxrs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * 
+ * Extracts the client certificate from headers defined by the {@code 
+ * clientCertificatePathHeaders} member list. The first element in the list is 
+ * header for the client's own certificate. Each additional header in the list
+ * will be checked and added to the resulting output.
+ * 
+ * @author jricher
+ *
+ * @since 2.8
+ *
+ */
+public class HeaderClientCertificateExtractor implements ClientCertificateExtractor
+{
+
+    /** 
+     * Headers to check for certificate path with proxy-forwarded certificate 
+     * information; the first entry is the client's certificate itself 
+     */
+    private String[] clientCertificateChainHeaders = {
+            "X-Ssl-Cert", // the client's certificate 
+            "X-Ssl-Cert-Chain-1", "X-Ssl-Cert-Chain-2", "X-Ssl-Cert-Chain-3", "X-Ssl-Cert-Chain-4" // the intermediate certificate path, not including the client's certificate or root
+    };
+    
+    /* (non-Javadoc)
+     * @see com.authlete.jaxrs.ClientCertificateExtractor#extractClientCertificateChain(javax.servlet.http.HttpServletRequest)
+     */
+    @Override
+    public String[] extractClientCertificateChain(HttpServletRequest request)
+    {
+        List<String> headerCerts = new ArrayList<>();
+        
+        // look through all the headers that we've been configured with and pull out their values
+        for (String headerName : getClientCertificateChainHeaders())
+        {
+            String header = request.getHeader(headerName);
+            if (header != null)
+            {
+                headerCerts.add(header);
+            }
+        }
+
+        if (headerCerts.isEmpty())
+        {
+            return null;
+        }
+        else
+        {
+            return headerCerts.toArray(new String[] {});
+        }
+    }
+
+    /**
+     * Get the headers that will be checked for the client certificate chain. The first element in 
+     * the list is header for the client's own certificate. Each additional header in the list
+     * will be checked and added to the resulting output.
+     */
+    public String[] getClientCertificateChainHeaders()
+    {
+        return clientCertificateChainHeaders;
+    }
+
+    /**
+     * Set the headers that will be checked for the client certificate chain. The first element in 
+     * the list is header for the client's own certificate. Each additional header in the list
+     * will be checked and added to the resulting output.
+     */
+    public HeaderClientCertificateExtractor setClientCertificateChainHeaders(String[] clientCertificateChainHeaders)
+    {
+        this.clientCertificateChainHeaders = clientCertificateChainHeaders;
+        
+        return this;
+    }
+
+}

--- a/src/main/java/com/authlete/jaxrs/HttpsRequestClientCertificateExtractor.java
+++ b/src/main/java/com/authlete/jaxrs/HttpsRequestClientCertificateExtractor.java
@@ -1,0 +1,72 @@
+/**
+ * 
+ */
+package com.authlete.jaxrs;
+
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.codec.binary.Base64;
+
+/**
+ * Extracts the client certificate from the incoming HTTPS request using the
+ * {@link javax.servlet.request.X509Certificate} attribute.
+ * 
+ * @author jricher
+ * 
+ * @since 2.8
+ *
+ */
+public class HttpsRequestClientCertificateExtractor implements ClientCertificateExtractor
+{
+
+    /*
+     * Used for handling PEM format certificates.
+     */
+    private Base64 base64 = new Base64(Base64.PEM_CHUNK_SIZE, "\n".getBytes());
+
+    /* (non-Javadoc)
+     * @see com.authlete.jaxrs.ClientCertificateExtractor#extractClientCertificateChain(javax.servlet.http.HttpServletRequest)
+     */
+    @Override
+    public String[] extractClientCertificateChain(HttpServletRequest request)
+    {
+        // try to get the certificates from the servlet context directly
+        X509Certificate[] certs = (X509Certificate[]) request.getAttribute("javax.servlet.request.X509Certificate");
+        
+        if (certs == null || certs.length == 0)
+        {
+            return null;
+        }
+        else 
+        {
+            String[] pemEncoded = new String[certs.length];
+            
+            try
+            {
+                for (int i = 0; i < certs.length; i++)
+                {
+                    // encode each certificate in PEM format
+                    StringBuilder sb = new StringBuilder();
+                    sb.append("-----BEGIN CERTIFICATE-----\n");
+                    sb.append(base64.encode(certs[i].getEncoded()));
+                    sb.append("\n-----END CERTIFICATE-----\n");
+
+                    pemEncoded[i] = sb.toString();
+                    
+                }
+            } catch (CertificateEncodingException e)
+            {
+                // TODO What should be done with this error?
+                e.printStackTrace();
+                return null;
+            }
+            
+            return pemEncoded;
+            
+        }
+    }
+
+}

--- a/src/main/java/com/authlete/jaxrs/TokenRequestHandler.java
+++ b/src/main/java/com/authlete/jaxrs/TokenRequestHandler.java
@@ -17,6 +17,8 @@
 package com.authlete.jaxrs;
 
 
+import java.util.Arrays;
+
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -90,6 +92,16 @@ public class TokenRequestHandler extends BaseHandler
      *         secret in a token request using <a href=
      *         "https://tools.ietf.org/html/rfc2617#section-2">Basic
      *         Authentication</a>.
+     *         
+     * @param clientCertificate 
+     *         The value of the client's mutual TLS certificate, in PEM format.
+     *         May be {@code null} if the client did not send a certificate.
+     *          
+     * @param clientCertificatePath
+     *         The path of the client's certificate, each in PEM format. Does not
+     *         include the client's certificate itself, this is passed in the
+     *         {@code clientCertificate} parameter. May be {@code null} if
+     *         the client did not send a certificate or path.
      *
      * @return
      *         A response that should be returned from the endpoint to the
@@ -98,7 +110,7 @@ public class TokenRequestHandler extends BaseHandler
      * @throws WebApplicationException
      *         An error occurred.
      */
-    public Response handle(MultivaluedMap<String, String> parameters, String authorization) throws WebApplicationException
+    public Response handle(MultivaluedMap<String, String> parameters, String authorization, String[] clientCertificatePath) throws WebApplicationException
     {
         // Convert the value of Authorization header (credentials of
         // the client application), if any, into BasicCredentials.
@@ -112,7 +124,7 @@ public class TokenRequestHandler extends BaseHandler
         try
         {
             // Process the given parameters.
-            return process(parameters, clientId, clientSecret);
+            return process(parameters, clientId, clientSecret, clientCertificatePath);
         }
         catch (WebApplicationException e)
         {
@@ -129,13 +141,25 @@ public class TokenRequestHandler extends BaseHandler
     /**
      * Process the parameters of the token request.
      */
-    private Response process(MultivaluedMap<String, String> parameters, String clientId, String clientSecret)
+    private Response process(MultivaluedMap<String, String> parameters, String clientId, String clientSecret, String[] clientCertificatePath)
     {
         // Extra properties to associate with an access token.
         Property[] properties = mSpi.getProperties();
 
+        String clientCertificate = null;
+        if (clientCertificatePath != null && clientCertificatePath.length > 0)
+        {
+            clientCertificate = clientCertificatePath[0]; // the first one is the client's certificate
+            
+            // if we have more in the path, pass them along separately without the first one
+            if (clientCertificatePath.length > 1)
+            {
+                clientCertificatePath = Arrays.copyOfRange(clientCertificatePath, 1, clientCertificatePath.length);
+            }
+        }
+        
         // Call Authlete's /api/auth/token API.
-        TokenResponse response = getApiCaller().callToken(parameters, clientId, clientSecret, properties);
+        TokenResponse response = getApiCaller().callToken(parameters, clientId, clientSecret, properties, clientCertificate, clientCertificatePath);
 
         // 'action' in the response denotes the next action which
         // this service implementation should take.

--- a/src/main/java/com/authlete/jaxrs/TokenRequestHandler.java
+++ b/src/main/java/com/authlete/jaxrs/TokenRequestHandler.java
@@ -93,14 +93,9 @@ public class TokenRequestHandler extends BaseHandler
      *         "https://tools.ietf.org/html/rfc2617#section-2">Basic
      *         Authentication</a>.
      *         
-     * @param clientCertificate 
-     *         The value of the client's mutual TLS certificate, in PEM format.
-     *         May be {@code null} if the client did not send a certificate.
-     *          
      * @param clientCertificatePath
-     *         The path of the client's certificate, each in PEM format. Does not
-     *         include the client's certificate itself, this is passed in the
-     *         {@code clientCertificate} parameter. May be {@code null} if
+     *         The path of the client's certificate, each in PEM format. The first
+     *         item in the array is the client's certificate itself. May be {@code null} if
      *         the client did not send a certificate or path.
      *
      * @return


### PR DESCRIPTION
Allows processing of MTLS bound access tokens through the library. Extraction functions around in BaseEndpoint, but these could be moved. Currently headers are hardcoded but these should be configurable. 