### PR TITLE
including support for mtls on Azure App Serv LB

### DIFF
--- a/src/main/java/com/authlete/jaxrs/HeaderClientCertificateExtractor.java
+++ b/src/main/java/com/authlete/jaxrs/HeaderClientCertificateExtractor.java
@@ -94,10 +94,12 @@ public class HeaderClientCertificateExtractor implements ClientCertificateExtrac
             "X-Ssl-Cert-Chain-1",
             "X-Ssl-Cert-Chain-2",
             "X-Ssl-Cert-Chain-3",
-            "X-Ssl-Cert-Chain-4"
-            // the intermediate certificate path, not including the client's
-            // certificate or root
+            "X-Ssl-Cert-Chain-4",    // the intermediate certificate path, not including the client's
+            						// certificate or root
+            "X-ARR-ClientCert" 		// Azure App Service Load balancer
+                                    // https://docs.microsoft.com/en-us/azure/app-service/app-service-web-configure-tls-mutual-auth
     );
+         
 
 
     @Override


### PR DESCRIPTION
Hi Taka,

I was trying to deploy the java-oauth-server on Azure and apply the FAPI Cert test on it, but the mTLS on App Service load balancer, has a fixed header name.
this patch include the name of the azure header on list of attributes to the search the client cert