### PR TITLE
Remove TestRequest object, and replace it with mocks.

### DIFF
--- a/src/test/java/com/authlete/jaxrs/util/RequestUrlResolverTest.java
+++ b/src/test/java/com/authlete/jaxrs/util/RequestUrlResolverTest.java
@@ -17,30 +17,10 @@ package com.authlete.jaxrs.util;
 
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.security.Principal;
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import javax.servlet.AsyncContext;
-import javax.servlet.DispatcherType;
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.ServletInputStream;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.Cookie;
+
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-import javax.servlet.http.HttpUpgradeHandler;
-import javax.servlet.http.Part;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 
 public class RequestUrlResolverTest
@@ -49,7 +29,7 @@ public class RequestUrlResolverTest
     public void test_by_configuration()
     {
         // Request
-        HttpServletRequest request = new TestRequest();
+        HttpServletRequest request = createMockRequest();
 
         // Resolver
         RequestUrlResolver resolver =
@@ -69,8 +49,8 @@ public class RequestUrlResolverTest
         String originalUrl = "https://example.com/path2?key2=value2";
 
         // Request
-        HttpServletRequest request = new TestRequest()
-                .addHeader("X-Forwarded-URL", originalUrl);
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getHeader("X-Forwarded-URL")).thenReturn(originalUrl);
 
         // Resolver
         RequestUrlResolver resolver = new RequestUrlResolver();
@@ -92,8 +72,8 @@ public class RequestUrlResolverTest
         String originalUrl = "https://example.com/path2?key2=value2";
 
         // Request
-        HttpServletRequest request = new TestRequest()
-                .addHeader(urlFieldName, originalUrl);
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getHeader(urlFieldName)).thenReturn(originalUrl);
 
         // Resolver
         RequestUrlResolver resolver = new RequestUrlResolver()
@@ -110,8 +90,8 @@ public class RequestUrlResolverTest
     public void test_by_forwarded_field()
     {
         // Request
-        HttpServletRequest request = new TestRequest()
-                .addHeader("Forwarded", "proto=https;host=example.com");
+        HttpServletRequest request = createMockRequest();
+        Mockito.when(request.getHeader("Forwarded")).thenReturn("proto=https;host=example.com");
 
         // Resolver
         RequestUrlResolver resolver = new RequestUrlResolver();
@@ -127,9 +107,9 @@ public class RequestUrlResolverTest
     public void test_by_de_facto_fields_x_proto()
     {
         // Request
-        HttpServletRequest request = new TestRequest()
-                .addHeader("X-Forwarded-Host", "example.com")
-                .addHeader("X-Forwarded-Proto", "https");
+        HttpServletRequest request = createMockRequest();
+        Mockito.when(request.getHeader("X-Forwarded-Host")).thenReturn("example.com");
+        Mockito.when(request.getHeader("X-Forwarded-Proto")).thenReturn("https");
 
         // Resolver
         RequestUrlResolver resolver = new RequestUrlResolver();
@@ -145,9 +125,9 @@ public class RequestUrlResolverTest
     public void test_by_de_facto_fields_x_protocol()
     {
         // Request
-        HttpServletRequest request = new TestRequest()
-                .addHeader("X-Forwarded-Host", "example.com")
-                .addHeader("X-Forwarded-Protocol", "https");
+        HttpServletRequest request = createMockRequest();
+        Mockito.when(request.getHeader("X-Forwarded-Host")).thenReturn("example.com");
+        Mockito.when(request.getHeader("X-Forwarded-Protocol")).thenReturn("https");
 
         // Resolver
         RequestUrlResolver resolver = new RequestUrlResolver();
@@ -163,9 +143,9 @@ public class RequestUrlResolverTest
     public void test_by_de_facto_fields_x_url_scheme()
     {
         // Request
-        HttpServletRequest request = new TestRequest()
-                .addHeader("X-Forwarded-Host", "example.com")
-                .addHeader("X-Url-Scheme", "https");
+        HttpServletRequest request = createMockRequest();
+        Mockito.when(request.getHeader("X-Forwarded-Host")).thenReturn("example.com");
+        Mockito.when(request.getHeader("X-Url-Scheme")).thenReturn("https");
 
         // Resolver
         RequestUrlResolver resolver = new RequestUrlResolver();
@@ -181,9 +161,9 @@ public class RequestUrlResolverTest
     public void test_by_de_facto_fields_x_forwarded_ssl_off()
     {
         // Request
-        HttpServletRequest request = new TestRequest()
-                .addHeader("X-Forwarded-Host", "example.com")
-                .addHeader("X-Forwarded-Ssl", "off");
+        HttpServletRequest request = createMockRequest();
+        Mockito.when(request.getHeader("X-Forwarded-Host")).thenReturn("example.com");
+        Mockito.when(request.getHeader("X-Forwarded-Ssl")).thenReturn("off");
 
         // Resolver
         RequestUrlResolver resolver = new RequestUrlResolver();
@@ -199,9 +179,9 @@ public class RequestUrlResolverTest
     public void test_by_de_facto_fields_x_forwarded_ssl_on()
     {
         // Request
-        HttpServletRequest request = new TestRequest()
-                .addHeader("X-Forwarded-Host", "example.com")
-                .addHeader("X-Forwarded-Ssl", "on");
+        HttpServletRequest request = createMockRequest();
+        Mockito.when(request.getHeader("X-Forwarded-Host")).thenReturn("example.com");
+        Mockito.when(request.getHeader("X-Forwarded-Ssl")).thenReturn("on");
 
         // Resolver
         RequestUrlResolver resolver = new RequestUrlResolver();
@@ -217,9 +197,9 @@ public class RequestUrlResolverTest
     public void test_by_de_facto_fields_front_end_https_off()
     {
         // Request
-        HttpServletRequest request = new TestRequest()
-                .addHeader("X-Forwarded-Host", "example.com")
-                .addHeader("Front-End-Https", "off");
+        HttpServletRequest request = createMockRequest();
+        Mockito.when(request.getHeader("X-Forwarded-Host")).thenReturn("example.com");
+        Mockito.when(request.getHeader("Front-End-Https")).thenReturn("off");
 
         // Resolver
         RequestUrlResolver resolver = new RequestUrlResolver();
@@ -235,9 +215,9 @@ public class RequestUrlResolverTest
     public void test_by_de_facto_fields_front_end_https_on()
     {
         // Request
-        HttpServletRequest request = new TestRequest()
-                .addHeader("X-Forwarded-Host", "example.com")
-                .addHeader("Front-End-Https", "on");
+        HttpServletRequest request = createMockRequest();
+        Mockito.when(request.getHeader("X-Forwarded-Host")).thenReturn("example.com");
+        Mockito.when(request.getHeader("Front-End-Https")).thenReturn("on");
 
         // Resolver
         RequestUrlResolver resolver = new RequestUrlResolver();
@@ -253,7 +233,8 @@ public class RequestUrlResolverTest
     public void test_by_request()
     {
         // Request
-        HttpServletRequest request = new TestRequest();
+        HttpServletRequest request = createMockRequest();
+        Mockito.when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/path"));
 
         // Resolver
         RequestUrlResolver resolver = new RequestUrlResolver();
@@ -265,425 +246,18 @@ public class RequestUrlResolverTest
     }
 
 
-    private static final class TestRequest implements HttpServletRequest
+    /**
+     * Creates a mock {@link HttpServletRequest} that by default has the URI set to `/path`
+     * and the query string set to `key=value`
+     *
+     * @return the constructed mock {@link HttpServletRequest}
+     */
+    private HttpServletRequest createMockRequest()
     {
-        private final Map<String, String> headers = new HashMap<>();
-
-
-        @Override
-        public Object getAttribute(String name)
-        {
-            return null;
-        }
-
-        @Override
-        public Enumeration<String> getAttributeNames()
-        {
-            return null;
-        }
-
-        @Override
-        public String getCharacterEncoding()
-        {
-            return null;
-        }
-
-        @Override
-        public void setCharacterEncoding(String env) throws UnsupportedEncodingException
-        {
-        }
-
-        @Override
-        public int getContentLength()
-        {
-            return 0;
-        }
-
-        @Override
-        public long getContentLengthLong()
-        {
-            return 0;
-        }
-
-        @Override
-        public String getContentType()
-        {
-            return null;
-        }
-
-        @Override
-        public ServletInputStream getInputStream() throws IOException
-        {
-            return null;
-        }
-
-        @Override
-        public String getParameter(String name)
-        {
-            return null;
-        }
-
-        @Override
-        public Enumeration<String> getParameterNames()
-        {
-            return null;
-        }
-
-        @Override
-        public String[] getParameterValues(String name)
-        {
-            return null;
-        }
-
-        @Override
-        public Map<String, String[]> getParameterMap()
-        {
-            return null;
-        }
-
-        @Override
-        public String getProtocol()
-        {
-            return null;
-        }
-
-        @Override
-        public String getScheme()
-        {
-            return null;
-        }
-
-        @Override
-        public String getServerName()
-        {
-            return null;
-        }
-
-        @Override
-        public int getServerPort()
-        {
-            return 0;
-        }
-
-        @Override
-        public BufferedReader getReader() throws IOException
-        {
-            return null;
-        }
-
-        @Override
-        public String getRemoteAddr()
-        {
-            return null;
-        }
-
-        @Override
-        public String getRemoteHost()
-        {
-            return null;
-        }
-
-        @Override
-        public void setAttribute(String name, Object o)
-        {
-        }
-
-        @Override
-        public void removeAttribute(String name)
-        {
-        }
-
-        @Override
-        public Locale getLocale()
-        {
-            return null;
-        }
-
-        @Override
-        public Enumeration<Locale> getLocales()
-        {
-            return null;
-        }
-
-        @Override
-        public boolean isSecure()
-        {
-            return false;
-        }
-
-        @Override
-        public RequestDispatcher getRequestDispatcher(String path)
-        {
-            return null;
-        }
-
-        @Override
-        public String getRealPath(String path)
-        {
-            return null;
-        }
-
-        @Override
-        public int getRemotePort()
-        {
-            return 0;
-        }
-
-        @Override
-        public String getLocalName()
-        {
-            return null;
-        }
-
-        @Override
-        public String getLocalAddr()
-        {
-            return null;
-        }
-
-        @Override
-        public int getLocalPort()
-        {
-            return 0;
-        }
-
-        @Override
-        public ServletContext getServletContext()
-        {
-            return null;
-        }
-
-        @Override
-        public AsyncContext startAsync() throws IllegalStateException
-        {
-            return null;
-        }
-
-        @Override
-        public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) throws IllegalStateException
-        {
-            return null;
-        }
-
-        @Override
-        public boolean isAsyncStarted()
-        {
-            return false;
-        }
-
-        @Override
-        public boolean isAsyncSupported()
-        {
-            return false;
-        }
-
-        @Override
-        public AsyncContext getAsyncContext()
-        {
-            return null;
-        }
-
-        @Override
-        public DispatcherType getDispatcherType()
-        {
-            return null;
-        }
-
-        @Override
-        public String getAuthType()
-        {
-            return null;
-        }
-
-        @Override
-        public Cookie[] getCookies()
-        {
-            return null;
-        }
-
-        @Override
-        public long getDateHeader(String name)
-        {
-            return 0;
-        }
-
-        @Override
-        public String getHeader(String name)
-        {
-            return headers.get(name.toLowerCase());
-        }
-
-        public TestRequest addHeader(String name, String value)
-        {
-            headers.put(name.toLowerCase(), value);
-
-            return this;
-        }
-
-        @Override
-        public Enumeration<String> getHeaders(String name)
-        {
-            return null;
-        }
-
-        @Override
-        public Enumeration<String> getHeaderNames()
-        {
-            return null;
-        }
-
-        @Override
-        public int getIntHeader(String name)
-        {
-            return 0;
-        }
-
-        @Override
-        public String getMethod()
-        {
-            return null;
-        }
-
-        @Override
-        public String getPathInfo()
-        {
-            return null;
-        }
-
-        @Override
-        public String getPathTranslated()
-        {
-            return null;
-        }
-
-        @Override
-        public String getContextPath()
-        {
-            return null;
-        }
-
-        @Override
-        public String getQueryString()
-        {
-            return "key=value";
-        }
-
-        @Override
-        public String getRemoteUser()
-        {
-            return null;
-        }
-
-        @Override
-        public boolean isUserInRole(String role)
-        {
-            return false;
-        }
-
-        @Override
-        public Principal getUserPrincipal()
-        {
-            return null;
-        }
-
-        @Override
-        public String getRequestedSessionId()
-        {
-            return null;
-        }
-
-        @Override
-        public String getRequestURI()
-        {
-            return "/path";
-        }
-
-        @Override
-        public StringBuffer getRequestURL()
-        {
-            return new StringBuffer("http://localhost:8080/path");
-        }
-
-        @Override
-        public String getServletPath()
-        {
-            return null;
-        }
-
-        @Override
-        public HttpSession getSession(boolean create)
-        {
-            return null;
-        }
-
-        @Override
-        public HttpSession getSession()
-        {
-            return null;
-        }
-
-        @Override
-        public String changeSessionId()
-        {
-            return null;
-        }
-
-        @Override
-        public boolean isRequestedSessionIdValid()
-        {
-            return false;
-        }
-
-        @Override
-        public boolean isRequestedSessionIdFromCookie()
-        {
-            return false;
-        }
-
-        @Override
-        public boolean isRequestedSessionIdFromURL()
-        {
-            return false;
-        }
-
-        @Override
-        public boolean isRequestedSessionIdFromUrl()
-        {
-            return false;
-        }
-
-        @Override
-        public boolean authenticate(HttpServletResponse response) throws IOException, ServletException
-        {
-            return false;
-        }
-
-        @Override
-        public void login(String username, String password) throws ServletException
-        {
-        }
-
-        @Override
-        public void logout() throws ServletException
-        {
-        }
-
-        @Override
-        public Collection<Part> getParts() throws IOException, ServletException
-        {
-            return null;
-        }
-
-        @Override
-        public Part getPart(String name) throws IOException, ServletException
-        {
-            return null;
-        }
-
-        @Override
-        public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) throws IOException, ServletException
-        {
-            return null;
-        }
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getRequestURI()).thenReturn("/path");
+        Mockito.when(request.getQueryString()).thenReturn("key=value");
+
+        return request;
     }
 }


### PR DESCRIPTION
Since when we package and release this codebase as the jakarta version we change the underlying dependencies and also version change them.

In this case, any interface changes between these dependencies and versions can cause problems only visible in the pipeline and the HttpServletResponse is one of these classes resulting in the TestRequest causing compilation failures. By removing this we make this area of the code more resistant to such version changes in the future.

This has been tested with both javax and jakarata dependencies.