### PR TITLE
bump java common version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <authlete-java-common.version>4.16</authlete-java-common.version>
+        <authlete-java-common.version>4.17</authlete-java-common.version>
         <gson.version>2.10.1</gson.version>
         <nimbus.version>9.31</nimbus.version>
         <javax.api.version>2.1</javax.api.version>


### PR DESCRIPTION
This PR is to bump the java-common library version from 4.16 -> 4.17

This adds in the fixes that was merged recently for [Add json setter annotations for ambiguous setters] into java common library and as jaxrs has dependency on java-common library, so its important to merge these changes into jaxrs too