### PR TITLE
chore: return response headers in Authlete API response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ target/
 .settings
 .project
 .classpath
+.idea/
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <authlete-java-common.version>4.21-SNAPSHOT</authlete-java-common.version>
+        <authlete-java-common.version>4.23</authlete-java-common.version>
         <gson.version>2.10.1</gson.version>
         <nimbus.version>9.31</nimbus.version>
         <javax.api.version>2.1</javax.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <authlete-java-common.version>4.20</authlete-java-common.version>
+        <authlete-java-common.version>4.21-SNAPSHOT</authlete-java-common.version>
         <gson.version>2.10.1</gson.version>
         <nimbus.version>9.31</nimbus.version>
         <javax.api.version>2.1</javax.api.version>
@@ -151,15 +151,15 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-site-plugin</artifactId>
                         <configuration>
-                            <reportPlugins>
-                                <plugin>
-                                    <groupId>org.apache.maven.plugins</groupId>
-                                    <artifactId>maven-javadoc-plugin</artifactId>
-                                    <configuration>
-                                        <additionalparam>-Xdoclint:-html</additionalparam>
-                                    </configuration>
-                                </plugin>
-                            </reportPlugins>
+<!--                            <reportPlugins>-->
+<!--                                <plugin>-->
+<!--                                    <groupId>org.apache.maven.plugins</groupId>-->
+<!--                                    <artifactId>maven-javadoc-plugin</artifactId>-->
+<!--                                    <configuration>-->
+<!--                                        <additionalparam>-Xdoclint:-html</additionalparam>-->
+<!--                                    </configuration>-->
+<!--                                </plugin>-->
+<!--                            </reportPlugins>-->
                         </configuration>
                     </plugin>
                 </plugins>

--- a/src/main/java/com/authlete/jaxrs/AuthorizationRequestHandler.java
+++ b/src/main/java/com/authlete/jaxrs/AuthorizationRequestHandler.java
@@ -17,8 +17,6 @@
 package com.authlete.jaxrs;
 
 
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MultivaluedMap;
@@ -153,9 +151,6 @@ public class AuthorizationRequestHandler extends BaseHandler
         // Call Authlete's /api/auth/authorization API.
         AuthorizationResponse response = getApiCaller().callAuthorization(parameters, authzOptions);
 
-        System.out.println("jaxrs - authorization request - process" + response.getResponseHeaders());
-        System.out.println(157);
-
         // 'action' in the response denotes the next action which
         // this service implementation should take.
         AuthorizationResponse.Action action = response.getAction();
@@ -168,39 +163,32 @@ public class AuthorizationRequestHandler extends BaseHandler
         switch (action)
         {
             case INTERNAL_SERVER_ERROR:
-                System.out.println(171);
                 // 500 Internal Server Error
                 return ResponseUtil.internalServerError(content);
 
             case BAD_REQUEST:
-                System.out.println(176);
                 // 400 Bad Request
                 return ResponseUtil.badRequest(content);
 
             case LOCATION:
-                System.out.println(181);
                 // 302 Found
                 return ResponseUtil.location(content);
 
             case FORM:
                 // 200 OK
-                System.out.println(187);
                 return ResponseUtil.form(content);
 
             case INTERACTION:
-                System.out.println(191);
                 // Process the authorization request with user interaction.
                 return handleInteraction(response);
 
             case NO_INTERACTION:
-                System.out.println(196);
                 // Process the authorization request without user interaction.
                 // The flow reaches here only when the authorization request
                 // contained prompt=none.
                 return handleNoInteraction(response, authzIssueOptions, authzFailOptions);
 
             default:
-                System.out.println(202);
                 // This never happens.
                 throw getApiCaller().unknownAction("/api/auth/authorization", action);
         }

--- a/src/main/java/com/authlete/jaxrs/AuthorizationRequestHandler.java
+++ b/src/main/java/com/authlete/jaxrs/AuthorizationRequestHandler.java
@@ -17,6 +17,8 @@
 package com.authlete.jaxrs;
 
 
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MultivaluedMap;
@@ -151,6 +153,9 @@ public class AuthorizationRequestHandler extends BaseHandler
         // Call Authlete's /api/auth/authorization API.
         AuthorizationResponse response = getApiCaller().callAuthorization(parameters, authzOptions);
 
+        System.out.println("jaxrs - authorization request - process" + response.getResponseHeaders());
+        System.out.println(157);
+
         // 'action' in the response denotes the next action which
         // this service implementation should take.
         AuthorizationResponse.Action action = response.getAction();
@@ -163,32 +168,39 @@ public class AuthorizationRequestHandler extends BaseHandler
         switch (action)
         {
             case INTERNAL_SERVER_ERROR:
+                System.out.println(171);
                 // 500 Internal Server Error
                 return ResponseUtil.internalServerError(content);
 
             case BAD_REQUEST:
+                System.out.println(176);
                 // 400 Bad Request
                 return ResponseUtil.badRequest(content);
 
             case LOCATION:
+                System.out.println(181);
                 // 302 Found
                 return ResponseUtil.location(content);
 
             case FORM:
                 // 200 OK
+                System.out.println(187);
                 return ResponseUtil.form(content);
 
             case INTERACTION:
+                System.out.println(191);
                 // Process the authorization request with user interaction.
                 return handleInteraction(response);
 
             case NO_INTERACTION:
+                System.out.println(196);
                 // Process the authorization request without user interaction.
                 // The flow reaches here only when the authorization request
                 // contained prompt=none.
                 return handleNoInteraction(response, authzIssueOptions, authzFailOptions);
 
             default:
+                System.out.println(202);
                 // This never happens.
                 throw getApiCaller().unknownAction("/api/auth/authorization", action);
         }

--- a/src/main/java/com/authlete/jaxrs/api/AuthleteApiJaxrsImpl.java
+++ b/src/main/java/com/authlete/jaxrs/api/AuthleteApiJaxrsImpl.java
@@ -42,6 +42,7 @@ import com.authlete.common.api.AuthleteApiException;
 import com.authlete.common.api.Options;
 import com.authlete.common.api.Settings;
 import com.authlete.common.conf.AuthleteConfiguration;
+import com.authlete.common.dto.ApiResponse;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.JWSAlgorithm;
@@ -413,6 +414,7 @@ public abstract class AuthleteApiJaxrsImpl implements AuthleteApi
     protected <TResponse> TResponse callGetApi(
             String auth, String path, Class<TResponse> responseClass, Map<String, Object[]> params, Options options)
     {
+        System.out.println("*** authlete-java-jaxrs - callGetAPI ***");
         WebTarget webTarget = getTarget().path(path);
 
         if (params != null)
@@ -428,7 +430,15 @@ public abstract class AuthleteApiJaxrsImpl implements AuthleteApi
 
         setCustomRequestHeaders(builder, options);
 
-        return builder.get(responseClass);
+        Response response = builder.get();
+        TResponse result = response.readEntity(responseClass);
+
+        if (result instanceof ApiResponse) {
+            System.out.println("Get response headers:" + response.getHeaders());
+            ((ApiResponse) result).setResponseHeaders(response.getStringHeaders());
+        }
+
+        return result;
     }
 
 
@@ -450,6 +460,7 @@ public abstract class AuthleteApiJaxrsImpl implements AuthleteApi
     protected <TResponse> TResponse callPostApi(
             String auth, String path, Object request, Class<TResponse> responseClass, Options options)
     {
+        System.out.println("*** authlete-java-jaxrs - callPostAPI ***");
         Builder builder = wrapWithDpop(getTarget()
                 .path(path)
                 .request(APPLICATION_JSON_TYPE), path, "POST")
@@ -457,7 +468,15 @@ public abstract class AuthleteApiJaxrsImpl implements AuthleteApi
 
         setCustomRequestHeaders(builder, options);
 
-        return builder.post(Entity.entity(request, JSON_UTF8_TYPE), responseClass);
+        Response response = builder.post(Entity.entity(request, JSON_UTF8_TYPE));
+
+        TResponse result = response.readEntity(responseClass);
+
+        if (result instanceof ApiResponse) {
+            System.out.println("Post response headers:" + response.getHeaders());
+            ((ApiResponse) result).setResponseHeaders(response.getStringHeaders());
+        }
+        return result;
     }
 
 

--- a/src/main/java/com/authlete/jaxrs/api/AuthleteApiJaxrsImpl.java
+++ b/src/main/java/com/authlete/jaxrs/api/AuthleteApiJaxrsImpl.java
@@ -414,7 +414,6 @@ public abstract class AuthleteApiJaxrsImpl implements AuthleteApi
     protected <TResponse> TResponse callGetApi(
             String auth, String path, Class<TResponse> responseClass, Map<String, Object[]> params, Options options)
     {
-        System.out.println("*** authlete-java-jaxrs - callGetAPI ***");
         WebTarget webTarget = getTarget().path(path);
 
         if (params != null)
@@ -430,15 +429,14 @@ public abstract class AuthleteApiJaxrsImpl implements AuthleteApi
 
         setCustomRequestHeaders(builder, options);
 
-        Response response = builder.get();
-        TResponse result = response.readEntity(responseClass);
+        Response httpResponse = builder.get();
+        TResponse apiResponseObject = httpResponse.readEntity(responseClass);
 
-        if (result instanceof ApiResponse) {
-            System.out.println("Get response headers:" + response.getHeaders());
-            ((ApiResponse) result).setResponseHeaders(response.getStringHeaders());
+        if (apiResponseObject instanceof ApiResponse) {
+            ((ApiResponse) apiResponseObject).setResponseHeaders(httpResponse.getStringHeaders());
         }
 
-        return result;
+        return apiResponseObject;
     }
 
 
@@ -460,7 +458,6 @@ public abstract class AuthleteApiJaxrsImpl implements AuthleteApi
     protected <TResponse> TResponse callPostApi(
             String auth, String path, Object request, Class<TResponse> responseClass, Options options)
     {
-        System.out.println("*** authlete-java-jaxrs - callPostAPI ***");
         Builder builder = wrapWithDpop(getTarget()
                 .path(path)
                 .request(APPLICATION_JSON_TYPE), path, "POST")
@@ -468,15 +465,14 @@ public abstract class AuthleteApiJaxrsImpl implements AuthleteApi
 
         setCustomRequestHeaders(builder, options);
 
-        Response response = builder.post(Entity.entity(request, JSON_UTF8_TYPE));
+        Response httpResponse = builder.post(Entity.entity(request, JSON_UTF8_TYPE));
 
-        TResponse result = response.readEntity(responseClass);
+        TResponse apiResponseObject = httpResponse.readEntity(responseClass);
 
-        if (result instanceof ApiResponse) {
-            System.out.println("Post response headers:" + response.getHeaders());
-            ((ApiResponse) result).setResponseHeaders(response.getStringHeaders());
+        if (apiResponseObject instanceof ApiResponse) {
+            ((ApiResponse) apiResponseObject).setResponseHeaders(httpResponse.getStringHeaders());
         }
-        return result;
+        return apiResponseObject;
     }
 
 


### PR DESCRIPTION
## References
ENG-3627

## Context / Summary
Returns response headers included in the Authlete ApiResonse from `authlete-java-common` in the response.

## Description / Changes Made
- Takes the response headers from the result of calling the API and makes them available in the `ApiResponse` object.

## Breaking Changes
No, this approach was chosen with backwards compatibility in mind.

## Testing Instructions

1. Checkout branch `retrieve-response-headers` of `authlete-java-common`, `authete-java-jaxrs` and `java-oauth-server`
2. Run `mvn clean install -Dgpg.skip=true` in each directory to make sure the code changes are installed in your local maven repository
3. Follow the instructions in https://www.authlete.com/developers/tutorial/signup/. Make sure you correctly configure `authlete.properties` in `java-oauth-server` to use your Authlete 3 service.
4. Follow the instruction in the doc up till the part where you click `Send Request`. This triggers the `/authorize` endpoint to be called. 
5. Inspect the logs of `java-oauth-server`. You should see a the response headers logged, which include a hardcoded request id that was included in the request.

<img width="860" alt="image" src="https://github.com/user-attachments/assets/96e9cb02-7624-4b06-8eff-2063876db9bd" />


Can use these branch to test:
https://github.com/authlete/java-oauth-server/compare/master...retrieve-response-headers
https://github.com/authlete/authlete-java-common/pull/116

## Added Tests?
TODO

## Related MRs
https://github.com/authlete/authlete-java-common/pull/116