### PR TITLE
docs: add missing changelog entries for v2.88 response header support

### DIFF
--- a/CHANGES.ja.md
+++ b/CHANGES.ja.md
@@ -1,6 +1,19 @@
 変更点
 ======
 
+2.88 (2025-10-07)
+-----------------
+
+- `pom.xml`
+    * authlete-java-common のバージョンを 4.20 から 4.23 へ更新。
+    * nimbus-jose-jwt のバージョンを 9.37.2 から 10.0.2 へ更新。
+
+- `AuthleteApiJaxrsImpl` クラス
+    * Authlete API 呼び出しから HTTP レスポンスヘッダーを抽出する機能を追加。
+    * `callGetApi()` と `callPostApi()` メソッドがレスポンスヘッダーをキャプチャし、
+      `setResponseHeaders()` メソッドを使用して `ApiResponse` オブジェクトに設定するように変更。
+    * これにより、API レスポンスから `Request-Id` などのヘッダーへのアクセスが可能に。
+
 2.87 (2025-05-03)
 -----------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,19 @@
 CHANGES
 =======
 
+2.88 (2025-10-07)
+-----------------
+
+- `pom.xml`
+    * Updated the version of authlete-java-common from 4.20 to 4.23.
+    * Updated the version of nimbus-jose-jwt from 9.37.2 to 10.0.2.
+
+- `AuthleteApiJaxrsImpl` class
+    * Added support for extracting HTTP response headers from Authlete API calls.
+    * The `callGetApi()` and `callPostApi()` methods now capture response headers
+      and set them on `ApiResponse` objects using the `setResponseHeaders()` method.
+    * This enables access to headers like `Request-Id` from API responses.
+
 2.87 (2025-05-03)
 -----------------
 


### PR DESCRIPTION
### Description
This PR adds the missing changelog documentation for version 2.88 of authlete-java-jaxrs. The response header extraction feature was already implemented and merged in PR #54, but the CHANGES files were not updated.

---

### What's Changed
Updated CHANGES.md with v2.88 release notes
Updated CHANGES.ja.md with Japanese translation

---